### PR TITLE
Add link to techtalk

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -15,6 +15,8 @@ header:
       url: https://gitter.im/psyplot
     - label: <i class="fas fa-fw fa-mail-bulk"></i> Join the mailing list
       url: https://www.listserv.dfn.de/sympa/subscribe/psyplot
+    - label: <i class="fas fa-fw fa-chalkboard-teacher"></i> TechTalk, Nov, 17th
+      url: https://www.dkrz.de/up/news-and-events/tech-talks/tech-talk-visualizing-unstructured-grids-from-scripts-and-gui-with-psyplot
 tagline: |
     Interactive Data Visualization from Python and GUIs.<br />
 


### PR DESCRIPTION
this PR adds a button with a link to the [DKRZ techtalk next tuesday](https://www.dkrz.de/up/news-and-events/tech-talks/tech-talk-visualizing-unstructured-grids-from-scripts-and-gui-with-psyplot) on the website